### PR TITLE
Update Fable.Core, make VSCode package dependent on Node package (needed for Events).

### DIFF
--- a/VSCode/paket.references
+++ b/VSCode/paket.references
@@ -1,2 +1,3 @@
 FSharp.Core
 Fable.Core
+Fable.Import.Node

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,3 +3,4 @@ source https://www.nuget.org/api/v2
 nuget FAKE
 nuget FSharp.Core
 nuget Fable.Core
+nuget Fable.Import.Node

--- a/paket.lock
+++ b/paket.lock
@@ -1,40 +1,43 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    Fable.Core (1.0.8)
-      FSharp.Core (>= 4.1.17) - restriction: || (>= net463) (>= netstandard1.6)
-      NETStandard.Library (>= 1.6.1) - restriction: || (>= net463) (>= netstandard1.6)
-    FAKE (4.61.3)
+    Fable.Core (1.1.10)
+      FSharp.Core (>= 4.2.1) - restriction: >= netstandard1.6
+      NETStandard.Library (>= 1.6.1) - restriction: >= netstandard1.6
+    Fable.Import.Node (0.1.2)
+      Fable.Core (>= 1.0.8) - restriction: >= netstandard1.6
+      FSharp.Core (>= 4.2.1) - restriction: >= netstandard1.6
+    FAKE (4.62.6)
     FSharp.Core (4.2.1)
-      System.Collections (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Console (>= 4.0) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Diagnostics.Tools (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Globalization (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.IO (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Linq (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Linq.Expressions (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Linq.Queryable (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Net.Requests (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Reflection (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Reflection.Extensions (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime.Numerics (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Text.RegularExpressions (>= 4.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading.Tasks (>= 4.0.11) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading.Thread (>= 4.0) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading.ThreadPool (>= 4.0.10) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Threading.Timer (>= 4.0.1) - restriction: || (>= net463) (>= netstandard1.6)
-    Microsoft.NETCore.Platforms (1.1) - restriction: || (>= net463) (>= netstandard1.6)
-    Microsoft.NETCore.Targets (1.1) - restriction: || (>= net463) (>= netstandard1.6)
-    Microsoft.Win32.Primitives (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-    NETStandard.Library (1.6.1) - restriction: || (>= net463) (>= netstandard1.6)
+      System.Collections (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Console (>= 4.0) - restriction: >= netstandard1.6
+      System.Diagnostics.Debug (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Diagnostics.Tools (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Globalization (>= 4.0.11) - restriction: >= netstandard1.6
+      System.IO (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq.Expressions (>= 4.1) - restriction: >= netstandard1.6
+      System.Linq.Queryable (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Net.Requests (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Reflection (>= 4.1) - restriction: >= netstandard1.6
+      System.Reflection.Extensions (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Resources.ResourceManager (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.1) - restriction: >= netstandard1.6
+      System.Runtime.Extensions (>= 4.1) - restriction: >= netstandard1.6
+      System.Runtime.Numerics (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Text.RegularExpressions (>= 4.1) - restriction: >= netstandard1.6
+      System.Threading (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Threading.Tasks (>= 4.0.11) - restriction: >= netstandard1.6
+      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: >= netstandard1.6
+      System.Threading.Thread (>= 4.0) - restriction: >= netstandard1.6
+      System.Threading.ThreadPool (>= 4.0.10) - restriction: >= netstandard1.6
+      System.Threading.Timer (>= 4.0.1) - restriction: >= netstandard1.6
+    Microsoft.NETCore.Platforms (1.1) - restriction: >= netstandard1.6
+    Microsoft.NETCore.Targets (1.1) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (< netstandard1.1) (>= netstandard1.6) (< monoandroid)) (&& (< netstandard1.2) (>= netstandard1.6) (< monoandroid)) (&& (< netstandard1.3) (>= netstandard1.6) (< monoandroid)) (&& (< netstandard1.5) (>= netstandard1.6) (< monoandroid)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= netcore1.1)
+    Microsoft.Win32.Primitives (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    NETStandard.Library (1.6.1) - restriction: >= netstandard1.6
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.0
       Microsoft.Win32.Primitives (>= 4.3) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
@@ -79,21 +82,21 @@ NUGET
       System.Threading.Timer (>= 4.3) - restriction: >= netstandard1.2
       System.Xml.ReaderWriter (>= 4.3) - restriction: >= netstandard1.0
       System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.0
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.native.System (4.3) - restriction: || (>= net463) (>= netstandard1.6)
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.native.System (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
-    runtime.native.System.IO.Compression (4.3) - restriction: || (>= net463) (>= netstandard1.6)
+    runtime.native.System.IO.Compression (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
-    runtime.native.System.Net.Http (4.3) - restriction: || (>= net463) (>= netstandard1.6)
+    runtime.native.System.Net.Http (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
-    runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: || (>= net463) (>= netstandard1.6)
+    runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
       runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
@@ -104,460 +107,462 @@ NUGET
       runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.1)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-    System.AppContext (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-    System.Buffers (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.1
-      System.Diagnostics.Tracing (>= 4.3) - restriction: >= netstandard1.1
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.1
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.1
-      System.Threading (>= 4.3) - restriction: >= netstandard1.1
-    System.Collections (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Collections.Concurrent (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-    System.Console (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-    System.Diagnostics.Debug (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Diagnostics.DiagnosticSource (4.3.1) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
-      System.Reflection (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== netstandard1.1) (>= netstandard1.3)
-    System.Diagnostics.Tools (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-    System.Diagnostics.Tracing (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-    System.Globalization (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Globalization.Calendars (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-    System.Globalization.Extensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
-    System.IO (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-    System.IO.Compression (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      runtime.native.System (>= 4.3) - restriction: >= netstandard1.3
-      runtime.native.System.IO.Compression (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Buffers (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-    System.IO.Compression.ZipFile (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Buffers (>= 4.3) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.Compression (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-    System.IO.FileSystem (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
-    System.IO.FileSystem.Primitives (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-    System.Linq (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-    System.Linq.Expressions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Linq (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.ObjectModel (>= 4.3) - restriction: >= netstandard1.6
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
-      System.Reflection.Emit (>= 4.3) - restriction: >= netstandard1.6
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-    System.Linq.Queryable (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Linq (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Linq.Expressions (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Net.Http (4.3.2) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      runtime.native.System (>= 4.3) - restriction: >= netstandard1.6
-      runtime.native.System.Net.Http (>= 4.3) - restriction: >= netstandard1.6
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Diagnostics.DiagnosticSource (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Globalization.Extensions (>= 4.3) - restriction: >= netstandard1.6
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
-      System.IO.FileSystem (>= 4.3) - restriction: >= netstandard1.6
-      System.Net.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== netstandard1.3) (>= netstandard1.6)
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= net46) (>= netstandard1.6)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.6)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.3) (>= netstandard1.6)
-    System.Net.Primitives (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-    System.Net.Requests (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      System.Net.Http (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Net.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      System.Net.WebHeaderCollection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.1) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-    System.Net.Sockets (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.Net.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
-    System.Net.WebHeaderCollection (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-    System.ObjectModel (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-    System.Reflection (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-    System.Reflection.Emit (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.IO (>= 4.3) - restriction: >= netstandard1.1
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.1
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: >= netstandard1.1
-      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.1
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.1
-    System.Reflection.Emit.ILGeneration (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.0
-      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.0
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
-    System.Reflection.Emit.Lightweight (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.0
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: >= netstandard1.0
-      System.Reflection.Primitives (>= 4.3) - restriction: >= netstandard1.0
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
-    System.Reflection.Extensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-    System.Reflection.Primitives (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-    System.Reflection.TypeExtensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
-    System.Resources.ResourceManager (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.0)
-    System.Runtime (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-    System.Runtime.Extensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.5)
-    System.Runtime.Handles (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-    System.Runtime.InteropServices (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (== netstandard1.2) (== netstandard1.3) (>= netstandard1.5)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (>= netstandard1.5)
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      runtime.native.System (>= 4.3) - restriction: >= netstandard1.1
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.1)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.1)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.1)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.1)
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.1
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.1)
-    System.Runtime.Numerics (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-    System.Security.Cryptography.Algorithms (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      runtime.native.System.Security.Cryptography.Apple (>= 4.3) - restriction: >= netstandard1.6
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
-      System.Collections (>= 4.3) - restriction: >= netstandard1.6
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= net463) (>= netstandard1.6)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== net46) (== net461) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-    System.Security.Cryptography.Cng (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-      System.IO (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (== net46) (== net461) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== net46) (== net461) (== netstandard1.3) (== netstandard1.4) (>= net463) (>= netstandard1.6)
-      System.Text.Encoding (>= 4.3) - restriction: || (== netstandard1.4) (>= netstandard1.6)
-    System.Security.Cryptography.Csp (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading (>= 4.3) - restriction: >= netstandard1.3
-    System.Security.Cryptography.Encoding (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: >= netstandard1.3
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections.Concurrent (>= 4.3) - restriction: >= netstandard1.3
-      System.Linq (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-    System.Security.Cryptography.OpenSsl (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: || (== monoandroid) (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: >= netstandard1.6
-      System.IO (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.6
-      System.Runtime (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.6
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.6
-      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.6
-    System.Security.Cryptography.Primitives (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.3
-      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
-      System.IO (>= 4.3) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
-    System.Security.Cryptography.X509Certificates (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      runtime.native.System (>= 4.3) - restriction: >= netstandard1.6
-      runtime.native.System.Net.Http (>= 4.3) - restriction: >= netstandard1.6
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.6
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Globalization.Calendars (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.IO.FileSystem (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.6
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime.Handles (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= netstandard1.6)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime.Numerics (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (== net46) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net461) (>= netstandard1.6)
-      System.Security.Cryptography.Cng (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Security.Cryptography.Csp (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (== net46) (== dnxcore50) (== netstandard1.3) (== netstandard1.4) (>= net461) (>= netstandard1.6)
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: >= netstandard1.6
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-    System.Text.Encoding (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Text.Encoding.Extensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Text.RegularExpressions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (== netstandard1.3) (>= netstandard1.6)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.6)
-    System.Threading (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Threading.Tasks (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-    System.Threading.Tasks.Extensions (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: >= netstandard1.0
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.0
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.0
-    System.Threading.Tasks.Parallel (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections.Concurrent (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.1) (>= netstandard1.3)
-    System.Threading.Thread (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-    System.Threading.ThreadPool (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Handles (>= 4.3) - restriction: >= netstandard1.3
-    System.Threading.Timer (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.2)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (== dnxcore50) (>= netstandard1.2)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.2)
-    System.Xml.ReaderWriter (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.IO.FileSystem (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Threading.Tasks.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-    System.Xml.XDocument (4.3) - restriction: || (>= net463) (>= netstandard1.6)
-      System.Collections (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Diagnostics.Tools (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Globalization (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.IO (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Reflection (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Text.Encoding (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Threading (>= 4.3) - restriction: || (== dnxcore50) (>= netstandard1.3)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (== dnxcore50) (== netstandard1.0) (>= netstandard1.3)
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.1) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.AppContext (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.6) (< monoandroid)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Buffers (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Runtime (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Threading (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+    System.Collections (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Collections.Concurrent (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Reflection (>= 4.3) - restriction: && (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Console (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Diagnostics.Debug (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Diagnostics.DiagnosticSource (4.4) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3)) (&& (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3)) (&& (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac))
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3)) (&& (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3)) (&& (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3)) (&& (< net45) (>= netstandard1.3) (< netcore2.0) (< xamarinmac))
+    System.Diagnostics.Tools (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+    System.Diagnostics.Tracing (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.Globalization (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Globalization.Calendars (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Globalization (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Globalization.Extensions (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Globalization (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.IO (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.IO.Compression (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      runtime.native.System (>= 4.3) - restriction: && (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      runtime.native.System.IO.Compression (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Buffers (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.IO.Compression.ZipFile (4.3) - restriction: >= netstandard1.6
+      System.Buffers (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO.Compression (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO.FileSystem (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.IO.FileSystem (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (>= net46) (&& (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Handles (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Threading.Tasks (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.IO.FileSystem.Primitives (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Linq (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.6) (< monoandroid) (< win8) (< wp8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.6) (< monoandroid) (< win8) (< wp8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Linq.Expressions (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Linq (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.ObjectModel (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection.Emit (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Linq.Queryable (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Linq (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Linq.Expressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Net.Http (4.3.2) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      runtime.native.System (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Net.Http (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.DiagnosticSource (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Globalization.Extensions (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.IO.FileSystem (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Net.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= net46) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Net.Primitives (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Net.Requests (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      System.Net.Http (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Net.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      System.Net.WebHeaderCollection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.0) (< netstandard1.1) (< monoandroid) (< win8) (< wp8))
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Net.Sockets (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Net.Primitives (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Threading.Tasks (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Net.WebHeaderCollection (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Collections (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.ObjectModel (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Reflection (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.Reflection.Emit (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection.Primitives (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Reflection.Emit.ILGeneration (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+      System.Reflection.Primitives (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+      System.Runtime (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+    System.Reflection.Emit.Lightweight (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+      System.Reflection.Primitives (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+      System.Runtime (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< wp8)
+    System.Reflection.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+    System.Reflection.Primitives (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+    System.Reflection.TypeExtensions (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Reflection (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.5) (< monoandroid)) (&& (< net46) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= net462) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.5) (< monoandroid)) (&& (< net46) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.Resources.ResourceManager (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)) (>= dnxcore50)
+    System.Runtime (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.2) (< monoandroid) (< win8) (< wp8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.2) (< monoandroid) (< win8) (< wp8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.Runtime.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50)
+    System.Runtime.Handles (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Runtime.InteropServices (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50) (>= netcore1.1)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50) (>= netcore1.1)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50) (>= netcore1.1)
+      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50) (>= netcore1.1)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< monoandroid) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= net462) (>= dnxcore50) (>= netcore1.1)
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< netstandard1.5) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= dnxcore50) (>= netcore1.1)
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: >= netstandard1.6
+      runtime.native.System (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Runtime.Numerics (4.3) - restriction: >= netstandard1.6
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Security.Cryptography.Algorithms (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      runtime.native.System.Security.Cryptography.Apple (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Collections (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= net463) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= net463) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Handles (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Numerics (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= net463) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= net461) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Security.Cryptography.Cng (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.IO (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< net46) (>= netstandard1.4)) (>= net461) (>= netstandard1.6)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< net46) (>= netstandard1.4)) (>= net461) (>= netstandard1.6)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.4)) (>= netstandard1.6)
+    System.Security.Cryptography.Csp (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Reflection (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Handles (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (>= net46) (&& (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= net46) (&& (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Threading (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Security.Cryptography.Encoding (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Collections (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Collections.Concurrent (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Linq (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Handles (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Security.Cryptography.OpenSsl (4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: || (>= net463) (>= netstandard1.6) (>= monoandroid)
+      System.Collections (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Handles (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.InteropServices (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Numerics (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= net463) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Text.Encoding (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Security.Cryptography.Primitives (4.3) - restriction: >= netstandard1.6
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Globalization (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.IO (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Threading (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Threading.Tasks (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Security.Cryptography.X509Certificates (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      runtime.native.System (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Net.Http (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Diagnostics.Debug (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Globalization.Calendars (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.IO (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.IO.FileSystem (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime.Numerics (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= net461) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Cng (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.Csp (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard1.3) (< netstandard1.4) (< monoandroid)) (&& (< net46) (>= netstandard1.4) (< netstandard1.6) (< monoandroid)) (>= net461) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Text.Encoding (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Text.Encoding (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Text.Encoding.Extensions (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Text.RegularExpressions (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< netcore1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Globalization (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< netcore1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< netcore1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.6) (< monoandroid) (< win8) (< wpa81)) (>= dnxcore50) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)) (>= netcore1.1)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< netcore1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Threading (>= 4.3) - restriction: || (>= dnxcore50) (&& (>= netstandard1.6) (< netcore1.1) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+    System.Threading (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Threading.Tasks (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Threading.Tasks.Extensions (4.3) - restriction: || (&& (>= dnxcore50) (>= netstandard1.6)) (&& (>= netstandard1.6) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac))
+      System.Collections (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)
+      System.Runtime (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)
+      System.Threading.Tasks (>= 4.3) - restriction: && (< net45) (>= netstandard1.0) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wp8) (< wpa81)
+    System.Threading.Tasks.Parallel (4.3) - restriction: >= netstandard1.6
+      System.Collections.Concurrent (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.1) (< netstandard1.3) (< monoandroid) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Threading.Thread (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Threading.ThreadPool (4.3) - restriction: >= netstandard1.6
+      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+      System.Runtime.Handles (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac)
+    System.Threading.Timer (4.3) - restriction: >= netstandard1.6
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net451) (>= netstandard1.2) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win81) (< wpa81)) (>= dnxcore50)
+      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< net451) (>= netstandard1.2) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win81) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net451) (>= netstandard1.2) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win81) (< wpa81)) (>= dnxcore50)
+    System.Xml.ReaderWriter (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO.FileSystem (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.Encoding.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading.Tasks.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+    System.Xml.XDocument (4.3) - restriction: >= netstandard1.6
+      System.Collections (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Diagnostics.Tools (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Globalization (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.IO (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Reflection (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Text.Encoding (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Threading (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)
+      System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< monoandroid) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< monotouch) (< xamarintvos) (< xamarinwatchos) (< xamarinios) (< xamarinmac) (< win8) (< wpa81)) (>= dnxcore50)


### PR DESCRIPTION
Turns out, the VSCode package needs `Fable.Import.Node.Events`, and up to this point it was referencing that module from `Fable.Core`, but the latest version of `Fable.Core` doesn't contain that module anymore, since it was moved out to its own package.