### PR TITLE
Fix #29: Update to use import statement

### DIFF
--- a/Animejs/Fable.Import.Animejs.fs
+++ b/Animejs/Fable.Import.Animejs.fs
@@ -1,4 +1,4 @@
-namespace Fable.Import.Animejs
+module Fable.Import.Animejs
 
 (*
   bindings based on typescript definitions located here: https://github.com/kohashi/types-npm-animejs/blob/master/index.d.ts
@@ -191,5 +191,5 @@ and [<StringEnum>] Direction =
     | Reverse
     | Alternate
 
-type [<Erase>]Globals =
-    [<Global>] static member anime with get(): AnimeStatic = jsNative and set(v: AnimeStatic): unit = jsNative
+[<Import("*", "animejs")>]
+let anime: AnimeStatic = jsNative

--- a/Animejs/RELEASE_NOTES.md
+++ b/Animejs/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 0.2.0
+
+* Update binding to support `import * from 'animejs'`
+
 ### 0.1.0
 
 * First push


### PR DESCRIPTION
```fs
// Before
open Fable.Import.Animejs
let instance = Globals.anime

// After
open Fable.Import.Animejs
let instance = anime

// or
open Fable.Import
let instance = Animejs.anime
```

As said in the issue support the `import` statement will allow us to include animejs using Webpack (easier to update deps in your project espacially usefull for the samples-pixi repo (PR is coming to this repo to show this)).

@whitetigle Please merge if you agree or tell me your feedback if you don't have the right :)