### PR TITLE
Node Import Fixups

### DIFF
--- a/Node/Buffer.fs
+++ b/Node/Buffer.fs
@@ -3,6 +3,7 @@ module rec Fable.Import.Node.Buffer
 open Fable.Core
 open Fable.Import.JS
 
+[<StringEnum>]
 type BufferEncoding =
     ///For 7-bit ASCII data only. This encoding is fast and will strip the high bit if set.
     | Ascii 
@@ -20,11 +21,6 @@ type BufferEncoding =
     | Binary
     ///  Encode each byte as two hexadecimal characters.
     | Hex
-
-[<StringEnum>]
-type MyStrings =
-    | Vertical
-    | [<CompiledName("Horizontal")>] Horizontal
 
 type Buffer = 
     abstract write: string: string * ?offset: float * ?length: float * ?encoding: string -> float
@@ -87,7 +83,6 @@ type Buffer =
     abstract isBuffer: obj: obj -> obj
     abstract isEncoding: encoding: string -> bool
     abstract byteLength: string: string * ?encoding: string -> float
-    abstract concat: list: ResizeArray<Buffer> * ?totalLength: float -> Buffer
     abstract compare: buf1: Buffer * buf2: Buffer -> float
     abstract alloc: size: float * ?fill: U3<string, Buffer, float> * ?encoding: string -> Buffer
     abstract allocUnsafe: size: float -> Buffer
@@ -104,6 +99,7 @@ type [<AllowNullLiteral>] BufferStatic =
     abstract from: buffer: Buffer -> Buffer
     abstract from: arrayBuffer: ArrayBuffer * ?byteOffset: float * ?length: float -> Buffer
     abstract from: str: string * ?encoding: string -> Buffer
+    abstract concat: list: Buffer [] * ?totalLength: float -> Buffer
 
 type [<AllowNullLiteral>] SlowBuffer =
     abstract prototype: Buffer with get, set

--- a/Node/Stream.fs
+++ b/Node/Stream.fs
@@ -180,7 +180,7 @@ type [<AllowNullLiteral>] Transform<'a, 'b> =
     /// It is possible that no output is generated from any given chunk of input data.
     /// The callback function must be called only when the current chunk is completely consumed. The first argument passed to the callback must be an Error object if an error occurred while processing the input or null otherwise. If a second argument is passed to the callback, it will be forwarded on to the readable.push() method.
     /// Transform._transform() is never called in parallel; streams implement a queue mechanism, and to receive the next chunk, callback must be called, either synchronously or asynchronously.
-    abstract _transform: chunk: 'a * encoding: string * cb: (Error option * 'b option -> unit) -> unit
+    abstract _transform: chunk: 'a * encoding: string * cb: (Error option -> 'b option -> unit) -> unit
     /// In some cases, a transform operation may need to emit an additional bit of data at the end of the stream. For example, a zlib compression stream will store an amount of internal state used to optimally compress the output. When the stream ends, however, that additional data needs to be flushed so that the compressed data will be complete.
     /// Custom Transform implementations may implement the transform._flush() method. This will be called when there is no more written data to be consumed, but before the 'end' event is emitted signaling the end of the Readable stream.
     /// Within the transform._flush() implementation, the readable.push() method may be called zero or more times, as appropriate. The callback function must be called when the flush operation is complete.

--- a/Node/Stream.fs
+++ b/Node/Stream.fs
@@ -165,12 +165,12 @@ type [<AllowNullLiteral>] TransformOptions<'a, 'b> =
     /// It is possible that no output is generated from any given chunk of input data.
     /// The callback function must be called only when the current chunk is completely consumed. The first argument passed to the callback must be an Error object if an error occurred while processing the input or null otherwise. If a second argument is passed to the callback, it will be forwarded on to the readable.push() method.
     /// Transform._transform() is never called in parallel; streams implement a queue mechanism, and to receive the next chunk, callback must be called, either synchronously or asynchronously.
-    abstract transform: 'a -> string -> (Error option * 'b option -> unit) -> unit option
+    abstract transform: Option<'a -> string -> (Error option -> 'b option -> unit) -> unit> with get, set
     /// In some cases, a transform operation may need to emit an additional bit of data at the end of the stream. For example, a zlib compression stream will store an amount of internal state used to optimally compress the output. When the stream ends, however, that additional data needs to be flushed so that the compressed data will be complete.
     /// Custom Transform implementations may implement the transform._flush() method. This will be called when there is no more written data to be consumed, but before the 'end' event is emitted signaling the end of the Readable stream.
     /// Within the transform._flush() implementation, the readable.push() method may be called zero or more times, as appropriate. The callback function must be called when the flush operation is complete.
     /// The transform._flush() method is prefixed with an underscore because it is internal to the class that defines it, and should never be called directly by user programs.
-    abstract flush: (Error option -> unit) -> unit option
+    abstract flush: ((Error option -> unit) -> unit) option with get, set
 
 type [<AllowNullLiteral>] Transform<'a, 'b> =
     inherit Writable<'a>
@@ -180,7 +180,7 @@ type [<AllowNullLiteral>] Transform<'a, 'b> =
     /// It is possible that no output is generated from any given chunk of input data.
     /// The callback function must be called only when the current chunk is completely consumed. The first argument passed to the callback must be an Error object if an error occurred while processing the input or null otherwise. If a second argument is passed to the callback, it will be forwarded on to the readable.push() method.
     /// Transform._transform() is never called in parallel; streams implement a queue mechanism, and to receive the next chunk, callback must be called, either synchronously or asynchronously.
-    abstract _transform: chunk: 'a * encoding: string * callback: (Error option * 'b option -> unit) -> unit
+    abstract _transform: chunk: 'a * encoding: string * cb: (Error option * 'b option -> unit) -> unit
     /// In some cases, a transform operation may need to emit an additional bit of data at the end of the stream. For example, a zlib compression stream will store an amount of internal state used to optimally compress the output. When the stream ends, however, that additional data needs to be flushed so that the compressed data will be complete.
     /// Custom Transform implementations may implement the transform._flush() method. This will be called when there is no more written data to be consumed, but before the 'end' event is emitted signaling the end of the Readable stream.
     /// Within the transform._flush() implementation, the readable.push() method may be called zero or more times, as appropriate. The callback function must be called when the flush operation is complete.


### PR DESCRIPTION
  - Make BufferEncoding a StringEnum (and remove dead sample code).
  - Make Buffer.concat static.
  - Change transform to take a curried callback instead of a tupled one.