### PR TITLE
Node/ChildProcess: Set exec and execFile callbacks to use curried args instead of a tuple

### DIFF
--- a/Node/ChildProcess.fs
+++ b/Node/ChildProcess.fs
@@ -38,13 +38,13 @@ type [<AllowNullLiteral>] ExecOptions =
 type IExports =
     abstract ChildProcess: ChildProcessStatic with get, set
     abstract spawn: command: string * ?args: ResizeArray<string> * ?options: obj -> ChildProcess
-    abstract exec: command: string * ?options: ExecOptions * ?callback:(ExecError option * U2<string, Buffer.Buffer> * U2<string, Buffer.Buffer> -> unit) -> ChildProcessStatic
+    abstract exec: command: string * ?options: ExecOptions * ?callback:(ExecError option -> U2<string, Buffer.Buffer> -> U2<string, Buffer.Buffer> -> unit) -> ChildProcessStatic
 
-    abstract execFile: file: string * ?callback: (ExecError option * Buffer.Buffer * Buffer.Buffer -> unit) -> ChildProcess
+    abstract execFile: file: string * ?callback: (ExecError option -> Buffer.Buffer -> Buffer.Buffer -> unit) -> ChildProcess
 
-    abstract execFile: file: string * ?args: ResizeArray<string> * ?callback: (ExecError option * Buffer.Buffer * Buffer.Buffer -> unit) -> ChildProcess
+    abstract execFile: file: string * ?args: ResizeArray<string> * ?callback: (ExecError option -> Buffer.Buffer -> Buffer.Buffer -> unit) -> ChildProcess
 
-    abstract execFile :file: string * ?args: ResizeArray<string> * ?options: ExecOptions * ?callback: (ExecError option * Buffer.Buffer * Buffer.Buffer -> unit) -> ChildProcess
+    abstract execFile :file: string * ?args: ResizeArray<string> * ?options: ExecOptions * ?callback: (ExecError option -> Buffer.Buffer -> Buffer.Buffer -> unit) -> ChildProcess
 
     abstract fork: modulePath: string * ?args: ResizeArray<string> * ?options: obj -> ChildProcess
 


### PR DESCRIPTION
Node/ChildProcess:
- Set exec and execFile callbacks to use curried args instead of a tuple

Signed-off-by: Will Johnson <william.c1.johnson@gmail.com>