### PR TITLE
PassThrough stream should take options

### DIFF
--- a/Node/Stream.fs
+++ b/Node/Stream.fs
@@ -194,8 +194,11 @@ type [<AllowNullLiteral>] TransformStatic =
 type [<AllowNullLiteral>] PassThrough<'a> =
     inherit Transform<'a, 'a>
 
+type PassThroughOptions<'a> = TransformOptions<'a, 'a>
+
 type [<AllowNullLiteral>] PassThroughStatic =
     [<Emit("new $0()")>] abstract Create<'a> : unit -> PassThrough<'a>
+    [<Emit("new $0($1)")>] abstract Create<'a> : passthroughOptions:PassThroughOptions<'a> -> PassThrough<'a>
 
 type IExports =
     abstract Stream: StreamStatic with get, set

--- a/Node/Stream.fs
+++ b/Node/Stream.fs
@@ -198,7 +198,7 @@ type PassThroughOptions<'a> = TransformOptions<'a, 'a>
 
 type [<AllowNullLiteral>] PassThroughStatic =
     [<Emit("new $0()")>] abstract Create<'a> : unit -> PassThrough<'a>
-    [<Emit("new $0($1)")>] abstract Create<'a> : passthroughOptions:PassThroughOptions<'a> -> PassThrough<'a>
+    [<Emit("new $0($1)")>] abstract Create<'a> : passThroughOptions:PassThroughOptions<'a> -> PassThrough<'a>
 
 type IExports =
     abstract Stream: StreamStatic with get, set


### PR DESCRIPTION
A `PassThrough` stream is a specialized `Transform` stream. As such it should take `TransformStreamOptions`.

Alias `TransformStreamOptions` as `PassThroughOptions` with a single generic param.