### PR TITLE
Add AnimInstance.finished Promise definition

### DIFF
--- a/Animejs/Fable.Import.Animejs.fs
+++ b/Animejs/Fable.Import.Animejs.fs
@@ -104,6 +104,7 @@ and [<AllowNullLiteral>] AnimInstance =
     abstract play: unit -> obj
     abstract reverse: unit -> obj
     abstract restart: unit -> obj
+    abstract finished: Promise<unit> with get, set
 
 and [<AllowNullLiteral>] instanceParams =
     abstract offset: FunctionBasedValues with get, set


### PR DESCRIPTION
Anime.js has a `.finished` Promise - https://github.com/juliangarnier/anime#promises - so I propose adding it to the import binding. Feel free to disregard/change if there's a better solution.