### PR TITLE
Update testing to reflect multiple projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jobs:
             stage: test
             env: Type='unit test'
             language: csharp
-            dotnet: 2.1.3
+            dotnet: 2.1.4
             mono: latest
             before_script:
                 - nvm install 8
@@ -12,12 +12,13 @@ jobs:
                 - cd test
                 - npm i
                 - dotnet restore
-                - dotnet fable npm-run test
+                - dotnet restore Node/NodeTest.fsproj
+                - dotnet fable npm-test
         -
             stage: deploy
             env: Type='node bindings'
             language: csharp
-            dotnet: 2.1.3
+            dotnet: 2.1.4
             mono: latest
             if: branch =~ ^v.+node$
             script:

--- a/test/Base.fsproj
+++ b/test/Base.fsproj
@@ -3,12 +3,5 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Node/Stream.Test.fs" />
-    <Compile Include="Node/ChildProcess.Test.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="../Node/Fable.Import.Node.fsproj" />
-  </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/test/Node/NodeTest.fsproj
+++ b/test/Node/NodeTest.fsproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Stream.Test.fs" />
+    <Compile Include="ChildProcess.Test.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../Node/Fable.Import.Node.fsproj" />
+  </ItemGroup>
+  <Import Project="../../.paket/Paket.Restore.targets" />
+</Project>

--- a/test/Node/jest.config.js
+++ b/test/Node/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'jest-fable-preprocessor',
+  displayName: 'Node Binding Tests'
+};

--- a/test/Node/paket.references
+++ b/test/Node/paket.references
@@ -1,0 +1,2 @@
+Fable.Core
+Fable.Import.Jest

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-    moduleFileExtensions: ['js', 'fs'],
-    transform: {
-      '^.+\\.(fs)$': 'jest-fable-preprocessor',
-      '^.+\\.js$': 'jest-fable-preprocessor/source/babel-jest.js'
-    },
-    testMatch: ['**/**/*.(Test.fs)'],
-    coveragePathIgnorePatterns: ['/packages/', 'test/']
-  };

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
-      "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+      "version": "7.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.38.tgz",
+      "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -43,12 +43,6 @@
           }
         }
       }
-    },
-    "@types/node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
-      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -205,6 +199,12 @@
       "requires": {
         "lodash": "4.17.4"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -416,13 +416,13 @@
       }
     },
     "babel-jest": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.0.4.tgz",
-      "integrity": "sha512-/Yt61fUpdFjetYlnpj280BPKEsPnK4mqzxDdo8DybPvrPNrLurbAF/WBjn2nnoi1Hc2Ippsf12/aOp8ys/Vl1A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.1.0.tgz",
+      "integrity": "sha512-5pKRFTlDr+x1JESNRd5leqvxEJk3dRwVvIXikB6Lr4BWZbBppk1Wp+BLUzxWL8tM+EYGLCWgfqkD35Sft8r8Lw==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.0.3"
+        "babel-preset-jest": "22.1.0"
       }
     },
     "babel-messages": {
@@ -455,9 +455,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.3.tgz",
-      "integrity": "sha512-Z0pOZFs0xDctwF0bPEKrnAzvbbgDi2vDFbQ0EdofnLI2bOa3P1H66gNLb2vMJJaa00VDjfiGhIocsHvBkqtyEQ==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.1.0.tgz",
+      "integrity": "sha512-Og5sjbOZc4XUI3njqwYhS6WLTlHQUJ/y5+dOqmst8eHrozYZgT4OMzAaYaxhk75c2fBVYwn7+mNEN97XDO7cOw==",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -798,12 +798,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.0.3.tgz",
-      "integrity": "sha512-FbMMniSMXFvkKldCf+e4Tuol/v3XMaIpIp8xiT1WFlEW3ZapTKDW9YgVt3hqcpZXsIGFf6eUF3Owxom7yFlI8w==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.1.0.tgz",
+      "integrity": "sha512-ps2UYz7IQpP2IgZ41tJjUuUDTxJioprHXD8fi9DoycKDGNqB3nAX/ggy1S3plaQd43ktBvMS1FkkyGNoBujFpg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.0.3",
+        "babel-plugin-jest-hoist": "22.1.0",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -895,13 +895,6 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
-    },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true,
-      "optional": true
     },
     "boom": {
       "version": "4.3.1",
@@ -1238,10 +1231,13 @@
       "dev": true
     },
     "domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
-      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -1370,6 +1366,12 @@
         "strip-eof": "1.0.0"
       }
     },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1389,17 +1391,17 @@
       }
     },
     "expect": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.0.3.tgz",
-      "integrity": "sha512-QapzeQkcA3jCx4pDnD07I4SPPxScKbey8TD/WwrnzmpHmL5q0dUtXfUt5OIFOjVBCg+C4zn4Y1zK9Rb9SIDL1g==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.1.0.tgz",
+      "integrity": "sha512-8K+8TjNnZq73KYtqNWKWTbYbN8z4loeL+Pn2bqpmtTdBtLNXJtpz9vkUcQlFsgKMDRA3VM8GXRA6qbV/oBF7Bw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "22.0.3",
-        "jest-get-type": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-regex-util": "22.0.3"
+        "jest-diff": "22.1.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-regex-util": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2670,6 +2672,16 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2735,9 +2747,9 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -2786,13 +2798,16 @@
       }
     },
     "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -2996,12 +3011,12 @@
       }
     },
     "jest": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.0.4.tgz",
-      "integrity": "sha512-S0tmgK5psULvt/11QzgAZWGpY5y5TkMRzd3T21Q13JzTx37Vx6F0Nw022c9Kc/IbEy+AHkKkGFVO5QafE8MrDg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.1.4.tgz",
+      "integrity": "sha512-cIPkn+OFGabazPesbhnYkadPftoO2Fo3w84QjeIP+A8eZ5qj7Zs4PuTemAW8StNMxySJr0KPk/LhYG2GUHLexQ==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.4"
+        "jest-cli": "22.1.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3031,42 +3046,44 @@
           }
         },
         "jest-cli": {
-          "version": "22.0.4",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.0.4.tgz",
-          "integrity": "sha512-f1lZRM13IwIINzjE3RebXQKtQLiKncpSrbJZ/aTZJXmzEWGdgSayW4ESyhU+xK3uGiJEUSzbHjwPY6nGJ8VbUA==",
+          "version": "22.1.4",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.1.4.tgz",
+          "integrity": "sha512-p7yOu0Q5uuXb3Q93qEg3LE6eNGgAGueakifxXNEqQx4b0lOl2YlC9t6BLQWNOJ+z42VWK/BIdFjf6lxKcTkjFA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.3.0",
+            "exit": "0.1.2",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "import-local": "1.0.0",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "22.0.3",
-            "jest-config": "22.0.4",
-            "jest-environment-jsdom": "22.0.4",
-            "jest-get-type": "22.0.3",
-            "jest-haste-map": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-regex-util": "22.0.3",
-            "jest-resolve-dependencies": "22.0.3",
-            "jest-runner": "22.0.4",
-            "jest-runtime": "22.0.4",
-            "jest-snapshot": "22.0.3",
-            "jest-util": "22.0.4",
-            "jest-worker": "22.0.3",
+            "jest-changed-files": "22.1.4",
+            "jest-config": "22.1.4",
+            "jest-environment-jsdom": "22.1.4",
+            "jest-get-type": "22.1.0",
+            "jest-haste-map": "22.1.0",
+            "jest-message-util": "22.1.0",
+            "jest-regex-util": "22.1.0",
+            "jest-resolve-dependencies": "22.1.0",
+            "jest-runner": "22.1.4",
+            "jest-runtime": "22.1.4",
+            "jest-snapshot": "22.1.2",
+            "jest-util": "22.1.4",
+            "jest-worker": "22.1.0",
             "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
+            "node-notifier": "5.2.1",
             "realpath-native": "1.0.0",
             "rimraf": "2.6.2",
             "slash": "1.0.0",
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "yargs": "10.0.3"
+            "yargs": "10.1.2"
           }
         },
         "strip-ansi": {
@@ -3090,31 +3107,31 @@
       }
     },
     "jest-changed-files": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.0.3.tgz",
-      "integrity": "sha512-CG7eNJNO9x1O/3J4Uhe2QXra1MnC9+KS1f2NeOg+7iQ+8dDCgxCtpusmKfu44TnEyKwkIDhDr6htPfPaI+Fwbw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.1.4.tgz",
+      "integrity": "sha512-EpqJhwt+N/wEHRT+5KrjagVrunduOfMgAb7fjjHkXHFCPRZoVZwl896S7krx7txf5hrMNUkpECnOnO2wBgzJCw==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
     },
     "jest-config": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.0.4.tgz",
-      "integrity": "sha512-NcBeixqHjHDZO9+pUj+365LQV2s65d2f0/IrwlUyv0xaJovRNc6eDvoJ/r2UUlHnqjP3Go+R0ECUsXPXjk4SHw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.1.4.tgz",
+      "integrity": "sha512-ZImFp7STrUDOgQLW5I5UloCiCRMh6HmMIYIoWqaQkxnR5ws7MuZFG/Ns9sZFyfrnyWCvcW91e+XcEfNeoa4Jew==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.0.4",
-        "jest-environment-node": "22.0.4",
-        "jest-get-type": "22.0.3",
-        "jest-jasmine2": "22.0.4",
-        "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.4",
-        "jest-validate": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-environment-jsdom": "22.1.4",
+        "jest-environment-node": "22.1.4",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.1.4",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.4",
+        "jest-util": "22.1.4",
+        "jest-validate": "22.1.2",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3149,15 +3166,15 @@
       }
     },
     "jest-diff": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.0.3.tgz",
-      "integrity": "sha512-Y7xN9Lc/NgFvR14lvjrJXB6x2x1LLe5NnMyzLvilBSSOyjy9uAVnR2Bt1YgzdfRrfaxsx7xFUVcqXLUnPkrJcA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.1.0.tgz",
+      "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3192,123 +3209,87 @@
       }
     },
     "jest-docblock": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.0.3.tgz",
-      "integrity": "sha512-LhviP2rqIg2IzS6m97W7T032oMrT699Tr6Njjhhl4FCLj+75BUy9CsSmGgfoVEql1uc+myBkssvcbn7T9xDR+A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.1.0.tgz",
+      "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
       "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.4.tgz",
-      "integrity": "sha512-vnjefLZlsNsmnjKcaXkx2IxTBNG40vfRVOdMfcfkPkq85JxFB7wzNtjLx+RIfiNpIZd04C1PXbF0aJIenY85Ng==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.1.4.tgz",
+      "integrity": "sha512-YGqFJzei/kq5BgQ8su7igLoCl34ytUffr5ZoqwLrDzCmXUKyIiuwBFbWe3xFMG/crlDb1emhBXdzWM1yDEDw5Q==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.3",
-        "jest-util": "22.0.4",
-        "jsdom": "11.5.1"
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.4",
+        "jsdom": "11.6.1"
       }
     },
     "jest-environment-node": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.4.tgz",
-      "integrity": "sha512-9vjNKb86UivvKCZCudMNixQgdMnOG7ql6iVYnaiK0CmvZ0WQD+mlM10NvgiWpRv4HstcnRL1pY/GSIHXAD6qXw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.1.4.tgz",
+      "integrity": "sha512-rQmtzgZVdyCzeXsE8i7Alw2483KSd2PYjssZWZYeNzonN/lBeUjjaOCgLWp6FspBzSTnYF7x6cN4umGZxYAhow==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.3",
-        "jest-util": "22.0.4"
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.4"
       }
     },
     "jest-fable-preprocessor": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/jest-fable-preprocessor/-/jest-fable-preprocessor-1.3.3.tgz",
-      "integrity": "sha512-b9HzvCeJGTy9AaABsi8sZL836e+NUvLEH6GJCndizBYi41q6got5+dHWWtOkYFJAE6nY7/DsZ4uVZ1p23FNcIg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jest-fable-preprocessor/-/jest-fable-preprocessor-1.4.0.tgz",
+      "integrity": "sha512-9PUxSRrAiUgNhx8gubZv+MNOszpt8zFcSbJEFbXA/YuYkisnJ1/I/nS+TLhGkORsEeX/zOk8ngeXM468jNvuRg==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "21.2.0",
-        "babel-plugin-istanbul": "4.1.4",
-        "babel-plugin-jest-hoist": "21.2.0",
+        "babel-jest": "22.1.0",
+        "babel-plugin-istanbul": "4.1.5",
+        "babel-plugin-jest-hoist": "22.1.0",
         "fable-utils": "1.0.6",
-        "find-babel-config": "1.1.0"
-      },
-      "dependencies": {
-        "babel-jest": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-          "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-istanbul": "4.1.4",
-            "babel-preset-jest": "21.2.0"
-          }
-        },
-        "babel-plugin-istanbul": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz",
-          "integrity": "sha1-GN3oS/POMp/d8/QQP66SFFbY5Yc=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "istanbul-lib-instrument": "1.9.1",
-            "test-exclude": "4.1.1"
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-          "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
-          "dev": true
-        },
-        "babel-preset-jest": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-          "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "21.2.0",
-            "babel-plugin-syntax-object-rest-spread": "6.13.0"
-          }
-        }
+        "find-babel-config": "1.1.0",
+        "glob": "7.1.2"
       }
     },
     "jest-get-type": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.3.tgz",
-      "integrity": "sha512-TaJnc/lnJQ3jwry+NUWkqaJmKrM/Ut3XdK89HfiqdI3DMRLd6Zb4wyKjwuNP37MEQqlNg0YWH4sbBR8D4exjCA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.0.3.tgz",
-      "integrity": "sha512-VosIMOFQFu1rTF+MvOWVuv2KVmZ9eTkRgfwW2yUAs6/AhwmIfXRl/tih+fIOYcHzU4Auu1G8Fvl2kkF5g0k6/A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.1.0.tgz",
+      "integrity": "sha512-vETdC6GboGlZX6+9SMZkXtYRQSKBbQ47sFF7NGglbMN4eyIZBODply8rlcO01KwBiAeiNCKdjUyfonZzJ93JEg==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.0.3",
-        "jest-worker": "22.0.3",
+        "jest-docblock": "22.1.0",
+        "jest-worker": "22.1.0",
         "micromatch": "2.3.11",
-        "sane": "2.2.0"
+        "sane": "2.3.0"
       }
     },
     "jest-jasmine2": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.0.4.tgz",
-      "integrity": "sha512-pn1XPHUkffHK6oNY1Dfl/+Rg0UuTdlg3aGDnjyK6dZzGEBeiH1uKuSgZEjy3Lj461l3atpzsQyw7ilXPyjFnUw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.1.4.tgz",
+      "integrity": "sha512-+KoRiG4PUwURB7UXei2jzxvbCebhXgTYS+xWl3FsSYUn3flcxdcOgAsFolx31Dkk/B1bVf1HIKt/B6Ubucp9aQ==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
-        "expect": "22.0.3",
+        "co": "4.6.0",
+        "expect": "22.1.0",
         "graceful-fs": "4.1.11",
-        "jest-diff": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-snapshot": "22.0.3",
-        "source-map-support": "0.5.0"
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-snapshot": "22.1.2",
+        "source-map-support": "0.5.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3338,9 +3319,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -3358,24 +3339,23 @@
       }
     },
     "jest-leak-detector": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.0.3.tgz",
-      "integrity": "sha512-xyVdAmcG8M3jWtVeadDUU6MAHLBrjkP4clz2UtTZ1gpe5bRLk27VjQOpzTwK20MkV/6iZQhSuRVuzHS5kD0HpA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.1.0.tgz",
+      "integrity": "sha512-8QsCWkncWAqdvrXN4yXQp9vgWF6CT3RkRey+d06SIHX913uXzAJhJdZyo6eE+uHVYMxUbxqW93npbUFhAR0YxA==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.0.3",
-        "weak": "1.0.1"
+        "pretty-format": "22.1.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.3.tgz",
-      "integrity": "sha512-FJbKpCR3K7YYE/Pnvy5OrLFgPEswpYWIfVtdwT2NC6pBARbYGX39KF3bTxS9yg2mv0YL2zHe3UbwzFsi9nFpVA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.1.0.tgz",
+      "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3410,12 +3390,12 @@
       }
     },
     "jest-message-util": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.0.3.tgz",
-      "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.1.0.tgz",
+      "integrity": "sha512-kftcoawOeOVUGuGWmMupJt7FGLK1pqOrh02FlJwtImmPGZ2yTWCTx2D+N/g95qD2jCbQ/ntH1goBixhAIIxL+g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.36",
+        "@babel/code-frame": "7.0.0-beta.38",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -3454,21 +3434,21 @@
       }
     },
     "jest-mock": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.0.3.tgz",
-      "integrity": "sha512-donODXcDG03EAEavc9xfJ7fBF/LNVjoZYkmj9DLrQ1B9YcT6wh8Xx7IYg25b8V/8F/eXPMAE0KK5q6Fqe6yAeg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.1.0.tgz",
+      "integrity": "sha512-gL3/C8ds6e1PWiOTsV7sIejPP/ECYQgDbwMzbNCc+ZFPuPH3EpwsVLGmQqPK6okgnDagimbbQnss3kPJ8HCMtA==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.0.3.tgz",
-      "integrity": "sha512-mplC9chiAotES3ClzNhy0SJcfHB2DivooKJZW+2hDdvP8LLB+OUI+D6bJd7sncbKUsyFcmblEvpm/zz/hef7HA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.0.4.tgz",
-      "integrity": "sha512-yoxHsX4MTT2Ra/dFia9VCunzsA/4jMBENMmLjREIUkCIP1edk/PZUOGVVf680Gw04CtmT5stETylcbmbL7hJBw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.1.4.tgz",
+      "integrity": "sha512-/HuCMeiTD6YJ+NF15bU1mal1r7Gov0GJozA7232XiYve7cOOnU2JwXBx3EQmcIuG38uNrRPjtgpiXkBqfnk4Og==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -3507,56 +3487,58 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.0.3.tgz",
-      "integrity": "sha512-u9MUNJIa9GJ0YFhvM0+Scr4tyX84nC42d3w18Cly1doY7pTT+9momm+TncpuDlFyB2aNmS8SfdEbiLr1e6tBwg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+      "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.0.3"
+        "jest-regex-util": "22.1.0"
       }
     },
     "jest-runner": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.0.4.tgz",
-      "integrity": "sha512-srBkbqmiSB+jzSaG652fmi3kS6rV6wS/4fOG8dxxBg3dCqNQcM2/L3TI3ZK0SwIAcdGJh5Gybs8aDboT8K9Cdw==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.1.4.tgz",
+      "integrity": "sha512-HAyZ0Q2Fyk7mlbtbSKP75hNs9IP0Md7kzPUN1uNKbvQfZkXA/e7P0ttzAIGQtEbRx656tYwkfWNW+hXvs1i4/g==",
       "dev": true,
       "requires": {
-        "jest-config": "22.0.4",
-        "jest-docblock": "22.0.3",
-        "jest-haste-map": "22.0.3",
-        "jest-jasmine2": "22.0.4",
-        "jest-leak-detector": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-runtime": "22.0.4",
-        "jest-util": "22.0.4",
-        "jest-worker": "22.0.3",
+        "exit": "0.1.2",
+        "jest-config": "22.1.4",
+        "jest-docblock": "22.1.0",
+        "jest-haste-map": "22.1.0",
+        "jest-jasmine2": "22.1.4",
+        "jest-leak-detector": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-runtime": "22.1.4",
+        "jest-util": "22.1.4",
+        "jest-worker": "22.1.0",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.0.4.tgz",
-      "integrity": "sha512-+7uEwf/4f8k1E/eViyGK6/M5yA4O3f6TdWViuqF9MV7vXwG2OVJu8YEZa5239nEnHJiwinXp4eZXX+HB4pQRPg==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.1.4.tgz",
+      "integrity": "sha512-r/UjVuQppDRwbUprDlLYdd8MTYY+H8H6BCqRujGjo5/QyIt3b0hppNoOQHF+0bHNtuz/sR9chJ9HJ3A1fiv9Pw==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "22.0.4",
+        "babel-jest": "22.1.0",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.0.4",
-        "jest-haste-map": "22.0.3",
-        "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.4",
+        "jest-config": "22.1.4",
+        "jest-haste-map": "22.1.0",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.4",
+        "jest-util": "22.1.4",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
         "slash": "1.0.0",
         "strip-bom": "3.0.0",
         "write-file-atomic": "2.3.0",
-        "yargs": "10.0.3"
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3597,17 +3579,17 @@
       }
     },
     "jest-snapshot": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.0.3.tgz",
-      "integrity": "sha512-e/a/EvMsY5XROWy4QWX6PvYziuJ8ttD6+QcnbogODWtx2LGhvVQOb7pmqGTo0tL/p0vzFetZA9GlZSh/EfMepg==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.1.2.tgz",
+      "integrity": "sha512-45co/M0gTe6Y6yHaJLydEZKHOFpFHESLah40jW35DWd3pd7q188bsi0oUY4Kls7PDXUamvTWuTKTZXCtzwSvCw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.0.3"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3642,17 +3624,17 @@
       }
     },
     "jest-util": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.0.4.tgz",
-      "integrity": "sha512-gNNPtcCFkVh7daKIl3/06eoQ90QXGXCyDOfyZ3IEyTWmHBdX3GvklcOtyGcdOvrYEubaZTfMcMKmEeo/6sRTog==",
+      "version": "22.1.4",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.1.4.tgz",
+      "integrity": "sha512-zM29idoVBPvmpsGubS7YmywVyPe4/m1wE2YhmKp0vVmrQmuby7ObuMqabp82EYlM0Rdp4GNEtaDamW9jg8lgTg==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
-        "is-ci": "1.0.10",
-        "jest-message-util": "22.0.3",
-        "jest-validate": "22.0.3",
+        "is-ci": "1.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-validate": "22.1.2",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -3688,15 +3670,15 @@
       }
     },
     "jest-validate": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.0.3.tgz",
-      "integrity": "sha512-GmlLmPCtrSQ3iB4A1uxcfjawaaQnwESCDcUg5tMxJKeBbmPdcWPAb6EWzvANxULPUV7hfPKLwg4xIPpi7cx1/g==",
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.1.2.tgz",
+      "integrity": "sha512-IjvMsV7GW5ghg5PTQvU23zJqTBmnq10eY+4n47awUeXYEGH27N+JajFPOg6tsN+OYvEPsohPquKoqQ5XBVs/ow==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
+        "jest-get-type": "22.1.0",
         "leven": "2.1.0",
-        "pretty-format": "22.0.3"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3731,9 +3713,9 @@
       }
     },
     "jest-worker": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.0.3.tgz",
-      "integrity": "sha512-fPdCTnogFQiR0CP6whEsIly2RfcHxvalqyLjhui6qa1SnOmHiX7L8k4Umo8CBIp5ndWY0+ej1o7OTE5MlzPabg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.1.0.tgz",
+      "integrity": "sha512-ezLueYAQowk5N6g2J7bNZfq4NWZvMNB5Qd24EmOZLcM5SXTdiFvxykZIoNiMj9C98cCbPaojX8tfR7b1LJwNig==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -3763,9 +3745,9 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
-      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.1.tgz",
+      "integrity": "sha512-x1vDo5CQuwsuP0w3kuU04vQdem9Q8apRV2PXp8GeSFQpgtYvSwbcypIbNgRrXu82O4TMroGYSAbu9wyVZHcehw==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
@@ -3776,22 +3758,24 @@
         "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "domexception": "1.0.0",
+        "domexception": "1.0.1",
         "escodegen": "1.9.0",
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
-        "parse5": "3.0.3",
-        "pn": "1.0.0",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
         "tough-cookie": "2.3.3",
+        "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "6.4.0",
-        "xml-name-validator": "2.0.1"
+        "ws": "4.0.0",
+        "xml-name-validator": "3.0.0"
       }
     },
     "jsesc": {
@@ -4083,9 +4067,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
@@ -4245,10 +4229,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -4256,8 +4243,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -4281,13 +4274,10 @@
       }
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.5.2"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -4351,10 +4341,19 @@
         "pinkie": "2.0.4"
       }
     },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      }
+    },
     "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "prelude-ls": {
@@ -4370,9 +4369,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.3.tgz",
-      "integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.1.0.tgz",
+      "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -4653,7 +4652,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-promise-core": {
@@ -4694,6 +4693,21 @@
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -4720,9 +4734,9 @@
       "dev": true
     },
     "sane": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-      "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.3.0.tgz",
+      "integrity": "sha512-6GB9zPCsqJqQPAGcvEkUPijM1ZUFI+A/DrscL++dXO3Ltt5q5mPDayGxZtr3cBRkrbb4akbwszVVkTIFefEkcg==",
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
@@ -4916,12 +4930,6 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -5106,6 +5114,12 @@
       "dev": true,
       "optional": true
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5123,9 +5137,9 @@
       }
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -5147,6 +5161,15 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
       }
     },
     "walker": {
@@ -5174,17 +5197,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "weak": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
-      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0"
       }
     },
     "webidl-conversions": {
@@ -5251,6 +5263,15 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5281,10 +5302,21 @@
         "signal-exit": "3.0.2"
       }
     },
+    "ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
+      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.1"
+      }
+    },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "y18n": {
@@ -5300,12 +5332,12 @@
       "dev": true
     },
     "yargs": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "dev": true,
       "requires": {
-        "cliui": "3.2.0",
+        "cliui": "4.0.0",
         "decamelize": "1.2.0",
         "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
@@ -5319,28 +5351,30 @@
         "yargs-parser": "8.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
           }
         }
       }

--- a/test/package.json
+++ b/test/package.json
@@ -1,15 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "test": "jest",
-    "coverage": "jest --coverage",
+    "test": "jest --projects Node",
     "test-watch": "jest --watchAll"
   },
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "jest": "^22.0.4",
-    "jest-fable-preprocessor": "^1.3.3"
+    "jest": "^22.1.4",
+    "jest-fable-preprocessor": "^1.4.0"
   }
 }

--- a/test/paket.references
+++ b/test/paket.references
@@ -1,3 +1,1 @@
 dotnet-fable
-Fable.Core
-Fable.Import.Jest


### PR DESCRIPTION
The latest version of `fable-jest` supports
running with multiple projects.

Add a new `fsproj` for the node tests specifically,
and update the jest config / `package.json` to
reflect newer changes.

We still need a `fsproj` at the top test level,
but that's only because it seems to be necessary
to run the fable clitool there.