### PR TITLE
OverSampleType.None breaks Option.None

### DIFF
--- a/Browser/Fable.Import.Browser.fs
+++ b/Browser/Fable.Import.Browser.fs
@@ -6688,7 +6688,7 @@ module Browser =
         | Triangle 
         | Custom 
      
-    and [<StringEnum>] OverSampleType = 
+    and [<StringEnum; RequireQualifiedAccess>] OverSampleType = 
         | None 
         | [<CompiledName("2x")>] X2 
         | [<CompiledName("4x")>] X4 


### PR DESCRIPTION
If you import latest Fable.Import.Browser then Option.None is shadowed and all the things break. This is rather ugly.